### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Package Version MCP Server
 
+[![smithery badge](https://smithery.ai/badge/mcp-package-version)](https://smithery.ai/server/mcp-package-version)
+
 An MCP server that provides tools for checking latest stable package versions from multiple package registries:
 
 - npm (Node.js/JavaScript)
@@ -14,6 +16,14 @@ This server helps LLMs ensure they're recommending up-to-date package versions w
 ![tooling with and without mcp-package-version](images/with-without.jpg)
 
 ## Running
+
+### Installing via Smithery
+
+To install Package Version for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-package-version):
+
+```bash
+npx -y @smithery/cli install mcp-package-version --client claude
+```
 
 **Configure MCP Settings**
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Package Version for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-package-version

Let me know if any tweaks have to be made!