### PR TITLE
Fixed version fetching for Java

### DIFF
--- a/src/handlers/java.ts
+++ b/src/handlers/java.ts
@@ -23,7 +23,7 @@ export class JavaHandler implements PackageHandler {
       })
 
       const doc = response.data?.response?.docs?.[0]
-      if (!doc?.latestVersion) {
+      if (!doc?.v) {
         throw new Error('Latest version not found')
       }
 
@@ -33,7 +33,7 @@ export class JavaHandler implements PackageHandler {
 
       const result: PackageVersion = {
         name,
-        latestVersion: doc.latestVersion,
+        latestVersion: doc.v,
         registry: 'maven',
       }
 


### PR DESCRIPTION
The response json uses field `v` for version. 
Added one example: `https://search.maven.org/solrsearch/select?q=g:%22org.hibernate%22%20AND%20a:%22hibernate-core%22&core=gav&rows=1&wt=json`
![image](https://github.com/user-attachments/assets/a229c3a7-004a-4e3e-9461-656897a3cbfd)