### PR TITLE
docs(rewrite): final release before rewrite in golang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.18](https://github.com/sammcj/mcp-package-version/compare/v0.1.17...v0.1.18) (2025-04-08)
+
+
+### Features
+
+* add github actions versions support ([#13](https://github.com/sammcj/mcp-package-version/issues/13)) ([39f31a3](https://github.com/sammcj/mcp-package-version/commit/39f31a36102a4993a1be7c8123a9e67fce91c034))
+
 ### [0.1.17](https://github.com/sammcj/mcp-package-version/compare/v0.1.16...v0.1.17) (2025-03-15)
 
 ### [0.1.16](https://github.com/sammcj/mcp-package-version/compare/v0.1.14...v0.1.16) (2025-03-04)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Package Version MCP Server
 
+**NOTE: As of version 2.0.0, this MCP server will be rewritten in Go, once released please visit https://github.com/sammcj/mcp-package-version for information on the updated command for your MCP client**
+
 [![smithery badge](https://smithery.ai/badge/mcp-package-version)](https://smithery.ai/server/mcp-package-version)
 
 An MCP server that provides tools for checking latest stable package versions from multiple package registries:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-package-version",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-package-version",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mcp-package-version",
       "version": "0.1.17",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-package-version",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "An MCP server to provide LLMs the latest (stable) version of packages in package.json and requirements.txt files",
   "author": {
     "name": "Sam McLeod",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "bump": "npx -y standard-version --skip.tag && git add . ; git commit -m 'chore: bump version' ; git push"
+    "bump": "npx -y standard-version --skip.tag && git add . ; git commit -m 'chore: bump version' ; git push",
+    "postinstall": "echo '\u001b[33m**NOTE: As of version 2.0.0, this MCP server will be rewritten in Go, once released please visit https://github.com/sammcj/mcp-package-version for information on the updated command for your MCP client**\u001b[0m'"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.7.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -517,6 +517,7 @@ class PackageVersionServer {
     const transport = new StdioServerTransport()
     await this.server.connect(transport)
     console.error('Package Version MCP server running on stdio')
+    console.error('\u001b[33m**NOTE: As of version 2.0.0, this MCP server will be rewritten in Go, once released please visit https://github.com/sammcj/mcp-package-version for information on the updated command for your MCP client**\u001b[0m')
   }
 }
 


### PR DESCRIPTION
Add warning notice about this being the final release before merging the go rewrite requiring a minor change to the client config and install process.